### PR TITLE
changed the max-height of list within DataTableView.js to 99% and it …

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -94,11 +94,17 @@ class App extends Component {
       })
     }
 
+    // DEV MODE - 
+    //
+    // isAuthenticated: true  || isAuthenicated: false
+    // userInfo: user || userInfo: null
+    //
+    //
     this.state = {
-      isAuthenticated: false,
+      isAuthenticated: true,
       authenticateUser: this.authenticateUser,
       deAuthenticateUser: this.deAuthenticateUser,
-      userInfo: null,
+      userInfo: user,
       firebase: firebase,
       test: null
     }

--- a/client/src/components/DataTableView/DataTableView.jsx
+++ b/client/src/components/DataTableView/DataTableView.jsx
@@ -10,18 +10,16 @@ const DataTableView = ({ entries }) => {
   const useStyles = makeStyles({
     root: {},
     entry: {
-      outlineStyle: 'solid',
-      outlineColor: 'pink',
       backgroundColor: '#d7ded9',
     },
     container: {
 
     },
     list: {
-      maxHeight: '50vh',
+      maxHeight: '99%',
       overflow: 'auto',
-
     },
+    
     paper: {
       height: '88%',
       maxHeight: '88%',
@@ -52,13 +50,9 @@ const DataTableView = ({ entries }) => {
 
   return (
     <Paper className={classes.paper}>
-
-
       <List className={classes.list}>
         {DataTableItems}
       </List>
-
-
     </Paper>
 
   );

--- a/client/src/composite-components/EventDataTable/EventDataTable.js
+++ b/client/src/composite-components/EventDataTable/EventDataTable.js
@@ -9,7 +9,7 @@ import { withStyles } from '@material-ui/styles';
 import { artistList, userList, dummyUsers, eventList } from '../../dummyData'
 
 
-class PatronDataTable extends React.Component {
+class EventDataTable extends React.Component {
     constructor(props) {
         super(props)
 
@@ -54,13 +54,16 @@ class PatronDataTable extends React.Component {
 
     render() {
         return (
-            <Box border={2} borderRadius={16} borderColor='#90a4ae' display='flex' flexDirection='column' style={{ maxHeight: "100%", height: "100%", backgroundColor: 'pink', padding: '1vw' }}>
+            <Container>
+            <Box border={2} borderRadius={16} borderColor='#90a4ae' display='flex' flexDirection='column' style={{ maxHeight: "50vh", height: "50vh", backgroundColor: 'pink', padding: '1vw' }}>
                 <DataTableViewController buttons={['Upcoming', 'Guest List']} handleFocusChange={this.handleFocusChange} />
-                <DataTableView entries={this.entries} focus={this.state.focus} style={{ maxHeight: '100%' }} />
+                <DataTableView entries={this.entries} focus={this.state.focus}  />
             </Box>
+            </Container>
+
 
         )
     }
 }
 
-export default (PatronDataTable);
+export default (EventDataTable);

--- a/client/src/composite-components/EventDataTable/index.js
+++ b/client/src/composite-components/EventDataTable/index.js
@@ -1,0 +1,2 @@
+import EventDataTable from './EventDataTable';
+export default EventDataTable;

--- a/client/src/composite-components/PatronDataTable/index.js
+++ b/client/src/composite-components/PatronDataTable/index.js
@@ -1,2 +1,0 @@
-import PatronDataTable from './PatronDataTable';
-export default PatronDataTable;

--- a/client/src/pages/EventPage/EventPage.js
+++ b/client/src/pages/EventPage/EventPage.js
@@ -5,7 +5,7 @@ import Box from '@material-ui/core/Box'
 
 
 import CurrentArtistDisplay from '../../composite-components/CurrentArtistDisplay';
-import PatronDataTable from '../../composite-components/PatronDataTable';
+import EventDataTable from '../../composite-components/EventDataTable';
 import ProfileDataTable from '../../composite-components/ProfileDataTable';
 import ViewSwitch from '../../components/ViewSwitch';
 
@@ -91,10 +91,10 @@ const EventPage = () => {
 
       <Grid  item container direction='row'>
         {/* <Grid style={{height:'100%'}} item xs={12}>
-            <PatronDataTable />
+            <EventDataTable />
           </Grid> */}
         <Box mb={1} className={classes.dataTableAndChat} >
-          <PatronDataTable />
+          <EventDataTable />
         </Box>
       </Grid>
 

--- a/client/stories/ProfileDataTable.stories.js
+++ b/client/stories/ProfileDataTable.stories.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import ProfileDataTable from '../src/composite-components/ProfileDataTable';
-import PatronDataTable from '../src/composite-components/PatronDataTable';
+import EventDataTable from '../src/composite-components/EventDataTable';
 
-import { artistList, eventList, userList } from './ProfileAvatar.stories';
+import { artistList, eventList, userList } from '../src/dummyData.js';
 
 
 
@@ -12,4 +12,4 @@ import { artistList, eventList, userList } from './ProfileAvatar.stories';
 storiesOf('Data Table with Controller', module)
     .addDecorator(story => <div style={{ padding: '3rem' }}>{story()}</div>)
     .add('ProfileDataTable', ()=> <ProfileDataTable entries={artistList} />)
-    .add('PatronDataTable', ()=> <PatronDataTable entries={artistList}/>)
+    .add('EventDataTable', ()=> <EventDataTable entries={artistList}/>)


### PR DESCRIPTION
…fixed the scaling problem with final entries on the list being cut. Before I was using a vh, but changing it to almost the entirety of the container allowed it to still scroll and never have hidden space beneath its parent element